### PR TITLE
Fix crash in Python 3.10+, value must be int

### DIFF
--- a/beeline.py
+++ b/beeline.py
@@ -279,7 +279,7 @@ class Beeline:
 
                     # Set progress
                     line_number += 1
-                    percent = (line_number/float(lines_total)) * 100
+                    percent = int((line_number/float(lines_total)) * 100)
                     progress.setValue(percent)
 
                     # Calculate waypoints for smooth geodesic


### PR DESCRIPTION
Python 3.10 does not automatically convert floats to int anymore for cases like this.

```
An error has occurred while executing Python code: 

TypeError: setValue(self, int): argument 1 has unexpected type 'float' 
Traceback (most recent call last):
  File "/home/user/.local/share/QGIS/QGIS3/profiles/default/python/plugins/Beeline/beeline.py", line 283, in run
    progress.setValue(percent)
TypeError: setValue(self, int): argument 1 has unexpected type 'float'
```